### PR TITLE
refactor: consolidate locate and locateAll into single locate method

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,13 +353,13 @@ await rdp.clipboard.set({ text: 'text to copy' });
 const text = await rdp.clipboard.get();
 
 // Locate text using OCR
-const matches = await rdp.locate('Cancel');
+const matches = await rdp.locate({ text: 'Cancel' });
 if (matches.length > 0) {
   await rdp.mouse.click({ x: matches[0].center_x, y: matches[0].center_y });
 }
 
 // Get all text on screen
-const allText = await rdp.locateAll();
+const allText = await rdp.locate({ all: true });
 
 // Automation (requires --enable-win-automation at connect)
 const snapshot = await rdp.automation.snapshot({ interactive: true });

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,18 @@ export interface ClipboardSetOptions {
   text: string;
 }
 
+/** Options for locate (OCR) operations. */
+export interface LocateOptions {
+  /** Text to search for. Required unless all is true. */
+  text?: string;
+  /** If true, returns all text on screen. */
+  all?: boolean;
+  /** Use glob-style pattern matching (* and ?). */
+  pattern?: boolean;
+  /** Case-sensitive matching (default: false). */
+  caseSensitive?: boolean;
+}
+
 // --- Request Types (for IPC) ---
 
 export interface ConnectRequest {


### PR DESCRIPTION
## Summary

- Consolidates `locate(text, options?)` and `locateAll()` into a single `locate(options)` method
- New interface: `locate({ text?, all?, pattern?, caseSensitive? })`
- Updated README.md with new API examples

## Breaking Change

The TypeScript API changes from:
```typescript
const matches = await rdp.locate('Cancel');
const allText = await rdp.locateAll();
```

To:
```typescript
const matches = await rdp.locate({ text: 'Cancel' });
const allText = await rdp.locate({ all: true });
```

## Test plan

- [x] TypeScript compiles successfully (`pnpm build:ts`)
- [x] Linter passes (`pnpm lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)