### PR TITLE
feat: add --process-timeout flag to automate run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ agent-rdp automate window focus "~*Notepad*"
 
 # Run PowerShell commands
 agent-rdp automate run "Get-Process" --wait
+agent-rdp automate run "Get-Process" --wait --process-timeout 5000  # With 5s timeout
 ```
 
 **Selector Types:**

--- a/crates/agent-rdp-protocol/src/automation.rs
+++ b/crates/agent-rdp-protocol/src/automation.rs
@@ -134,6 +134,9 @@ pub enum AutomateRequest {
         /// Run with hidden window.
         #[serde(default)]
         hidden: bool,
+        /// Timeout in milliseconds when waiting.
+        #[serde(default = "default_run_timeout")]
+        timeout_ms: u64,
     },
 
     /// Wait for an element to reach a state.
@@ -158,6 +161,10 @@ fn default_max_depth() -> u32 {
 
 fn default_wait_timeout() -> u64 {
     30000
+}
+
+fn default_run_timeout() -> u64 {
+    10000
 }
 
 /// Scroll direction for automation.

--- a/crates/agent-rdp/src/cli.rs
+++ b/crates/agent-rdp/src/cli.rs
@@ -465,6 +465,10 @@ pub enum AutomateAction {
         /// Run with hidden window
         #[arg(long)]
         hidden: bool,
+
+        /// Process timeout in milliseconds when waiting (default: 10000)
+        #[arg(long = "process-timeout")]
+        process_timeout: Option<u64>,
     },
 
     /// Wait for an element to reach a state

--- a/crates/agent-rdp/src/cli/commands/automate.rs
+++ b/crates/agent-rdp/src/cli/commands/automate.rs
@@ -106,11 +106,13 @@ pub async fn run(
             args: cmd_args,
             wait,
             hidden,
+            process_timeout,
         } => AutomateRequest::Run {
             command,
             args: cmd_args,
             wait,
             hidden,
+            timeout_ms: process_timeout.unwrap_or(10000),
         },
 
         AutomateAction::WaitFor {

--- a/skills/agent-rdp/SKILL.md
+++ b/skills/agent-rdp/SKILL.md
@@ -177,10 +177,10 @@ agent-rdp automate window restore
 agent-rdp automate window close "~*Notepad*"
 
 # Run commands/apps (best way to open apps)
-agent-rdp automate run "notepad.exe"                    # Open Notepad
-agent-rdp automate run "Start-Process ms-settings:" --wait  # Open Settings
-agent-rdp automate run "calc.exe"                       # Open Calculator
-agent-rdp automate run "Get-Process" --wait             # PowerShell command
+agent-rdp automate run "notepad.exe"                                        # Open Notepad
+agent-rdp automate run "Start-Process ms-settings:" --wait                  # Open Settings
+agent-rdp automate run "calc.exe"                                           # Open Calculator
+agent-rdp automate run "Get-Process" --wait --process-timeout 5000          # With 5s timeout
 
 # Wait for element
 agent-rdp automate wait-for <selector> --timeout 5000

--- a/src/automation.ts
+++ b/src/automation.ts
@@ -54,6 +54,8 @@ export interface RunOptions {
   wait?: boolean;
   /** Run with hidden window. */
   hidden?: boolean;
+  /** Process timeout in milliseconds when waiting (default: 10000). */
+  processTimeout?: number;
 }
 
 export interface WaitForOptions {
@@ -336,6 +338,7 @@ export class AutomationController {
       args: options.args ?? [],
       wait: options.wait ?? false,
       hidden: options.hidden ?? true,
+      timeout_ms: options.processTimeout ?? 10000,
     });
     return response.data as unknown as AutomationRunResult;
   }


### PR DESCRIPTION
## Summary
- Add `--process-timeout` flag to `automate run` command to prevent indefinite blocking when using `--wait`
- Default timeout is 10 seconds (10000ms)
- PowerShell script now uses async I/O and `WaitForExit(timeout)` to properly timeout

## Test plan
- [x] Verified timeout works: `agent-rdp automate run "Start-Sleep -Seconds 30" --wait --process-timeout 5000` times out after 5s with proper error
- [x] Verified quick commands still work: `agent-rdp automate run "Write-Output 'hello'" --wait` returns output
- [x] Builds successfully (`cargo build`, `pnpm build:ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)