### PR TITLE
feat: improve snapshot defaults with depth limit and truncation indicator

### DIFF
--- a/crates/agent-rdp-daemon/src/handlers/automate.rs
+++ b/crates/agent-rdp-daemon/src/handlers/automate.rs
@@ -166,6 +166,8 @@ fn parse_snapshot_response(data: serde_json::Value) -> anyhow::Result<Accessibil
         .unwrap_or("unknown")
         .to_string();
     let ref_count = data["ref_count"].as_u64().unwrap_or(0) as u32;
+    let truncated = data["truncated"].as_bool().unwrap_or(false);
+    let max_depth = data["max_depth"].as_u64().unwrap_or(5) as u32;
     let root_data = &data["root"];
 
     let root = parse_element(root_data)?;
@@ -173,6 +175,8 @@ fn parse_snapshot_response(data: serde_json::Value) -> anyhow::Result<Accessibil
     Ok(AccessibilitySnapshot {
         snapshot_id,
         ref_count,
+        truncated,
+        max_depth,
         root,
     })
 }

--- a/crates/agent-rdp-protocol/src/automation.rs
+++ b/crates/agent-rdp-protocol/src/automation.rs
@@ -215,6 +215,12 @@ pub struct AccessibilitySnapshot {
     pub snapshot_id: String,
     /// Total number of elements with refs.
     pub ref_count: u32,
+    /// Whether the tree was truncated due to depth limit.
+    #[serde(default)]
+    pub truncated: bool,
+    /// Maximum depth used for this snapshot.
+    #[serde(default)]
+    pub max_depth: u32,
     /// Root element of the tree.
     pub root: AccessibilityElement,
 }

--- a/crates/agent-rdp/src/cli.rs
+++ b/crates/agent-rdp/src/cli.rs
@@ -334,9 +334,9 @@ pub enum AutomateAction {
         #[arg(short = 'c', long)]
         compact: bool,
 
-        /// Maximum tree depth (default: 10)
-        #[arg(short = 'd', long)]
-        depth: Option<u32>,
+        /// Maximum tree depth (default: 5)
+        #[arg(short = 'd', long, default_value = "5")]
+        depth: u32,
 
         /// Scope to a specific element (window, panel, etc.) via selector
         #[arg(short = 's', long)]

--- a/crates/agent-rdp/src/cli/commands/automate.rs
+++ b/crates/agent-rdp/src/cli/commands/automate.rs
@@ -33,7 +33,7 @@ pub async fn run(
         } => AutomateRequest::Snapshot {
             interactive_only: interactive,
             compact,
-            max_depth: depth.unwrap_or(10),
+            max_depth: depth,
             selector,
             focused,
         },

--- a/crates/agent-rdp/src/output.rs
+++ b/crates/agent-rdp/src/output.rs
@@ -93,6 +93,12 @@ impl Output {
                 // Print full accessibility tree like agent-browser
                 println!("Snapshot ID: {}", snapshot.snapshot_id);
                 println!("Elements: {}", snapshot.ref_count);
+                if snapshot.truncated {
+                    println!(
+                        "[Truncated at depth {} - use -d to increase or -s to scope to a window]",
+                        snapshot.max_depth
+                    );
+                }
                 println!();
                 self.print_element_tree(&snapshot.root, 0);
             }

--- a/src/automation.ts
+++ b/src/automation.ts
@@ -17,7 +17,7 @@ export interface SnapshotOptions {
   interactive?: boolean;
   /** Compact mode - remove empty structural elements. */
   compact?: boolean;
-  /** Maximum tree depth (default: 10). */
+  /** Maximum tree depth (default: 5). */
   depth?: number;
   /** Scope to a specific element (window, panel, etc.) via selector. */
   selector?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -397,6 +397,10 @@ export interface AutomationSnapshot {
   type: 'snapshot';
   snapshot_id: string;
   ref_count: number;
+  /** Whether the tree was truncated due to depth limit. */
+  truncated?: boolean;
+  /** Maximum depth used for this snapshot. */
+  max_depth?: number;
   root: AutomationElement;
 }
 


### PR DESCRIPTION
## Summary
- Change default snapshot depth from 10 to 5 for faster responses
- Add `truncated` flag to indicate when depth limit cuts off elements
- Add `max_depth` field to response for transparency
- Show helpful message when truncated: suggest `-d` to increase or `-s` to scope

## Changes
- **snapshot.ps1**: Default depth 5, track `$script:WasTruncated`, return `truncated`/`max_depth`
- **automation.rs (protocol)**: Add `truncated` and `max_depth` fields to `AccessibilitySnapshot`
- **cli.rs**: Change depth from `Option<u32>` to `u32` with default 5
- **automate.rs (handler)**: Parse new fields from JSON response
- **output.rs**: Show truncation warning with suggestions
- **types.ts/automation.ts**: Update TypeScript interfaces

## Test plan
- [ ] `agent-rdp automate snapshot` - uses depth 5 by default
- [ ] `agent-rdp automate snapshot -d 3` - shows truncation warning if applicable
- [ ] `agent-rdp automate snapshot -d 20` - no truncation for most UIs

🤖 Generated with [Claude Code](https://claude.ai/code)