### PR TITLE
fix: set working directory to user profile for run command

### DIFF
--- a/crates/agent-rdp-daemon/src/automation/scripts/lib/actions.ps1
+++ b/crates/agent-rdp-daemon/src/automation/scripts/lib/actions.ps1
@@ -493,6 +493,7 @@ function Invoke-Run {
     $startInfo = New-Object System.Diagnostics.ProcessStartInfo
     $startInfo.FileName = "powershell.exe"
     $startInfo.Arguments = "-NoProfile -Command `"$command $commandArgs`""
+    $startInfo.WorkingDirectory = $env:USERPROFILE
     $startInfo.UseShellExecute = $false
     $startInfo.RedirectStandardOutput = $wait
     $startInfo.RedirectStandardError = $wait


### PR DESCRIPTION
## Summary
- Sets the working directory for the `run` automation command to `$env:USERPROFILE` (e.g., `C:\Users\<username>`)
- Previously inherited from the agent process, which was the PowerShell script's directory

## Test plan
- [ ] Run a command via automation and verify it executes in the user's home directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)