### PR TITLE
feat!: rename invoke to click with mouse-based implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A CLI tool for AI agents to control Windows Remote Desktop sessions, built on [I
 - **Keyboard input** - Type text, press key combinations (Ctrl+C, Alt+Tab, etc.)
 - **Clipboard sync** - Copy/paste text between local machine and remote Windows
 - **Drive mapping** - Map local directories as network drives on the remote machine
-- **UI Automation** - Interact with Windows applications via accessibility API using native patterns (invoke, select, toggle, expand)
+- **UI Automation** - Interact with Windows applications via accessibility API (click, select, toggle, expand)
 - **OCR text location** - Find text on screen using OCR when UI Automation isn't available
 - **JSON output** - Structured output for AI agent consumption
 - **Session management** - Multiple named sessions with automatic daemon lifecycle
@@ -190,8 +190,9 @@ agent-rdp automate snapshot -s "~*Notepad*" # Scope to a window/element
 agent-rdp automate snapshot -i -c -d 5      # Combine options
 
 # Pattern-based element operations (refs use @eN format)
-agent-rdp automate invoke "#SaveButton"    # Invoke button (InvokePattern)
-agent-rdp automate invoke "@e5"            # By ref number from snapshot
+agent-rdp automate click "#SaveButton"     # Click button
+agent-rdp automate click "@e5"             # Click by ref number from snapshot
+agent-rdp automate click "@e5" -d          # Double-click (for file list items)
 agent-rdp automate select "@e10"           # Select item (SelectionItemPattern)
 agent-rdp automate toggle "@e7"            # Toggle checkbox (TogglePattern)
 agent-rdp automate expand "@e3"            # Expand menu (ExpandCollapsePattern)
@@ -364,7 +365,8 @@ const allText = await rdp.locate({ all: true });
 
 // Automation (requires --enable-win-automation at connect)
 const snapshot = await rdp.automation.snapshot({ interactive: true });
-await rdp.automation.invoke('@e5');          // Invoke button by ref
+await rdp.automation.click('@e5');           // Click button by ref
+await rdp.automation.click('@e5', { doubleClick: true }); // Double-click
 await rdp.automation.select('@e10');         // Select item
 await rdp.automation.toggle('@e7');          // Toggle checkbox
 await rdp.automation.expand('@e3');          // Expand menu

--- a/crates/agent-rdp-daemon/src/automation/file_ipc.rs
+++ b/crates/agent-rdp-daemon/src/automation/file_ipc.rs
@@ -276,15 +276,16 @@ mod tests {
     }
 
     #[test]
-    fn test_serialize_invoke_request() {
+    fn test_serialize_click_request() {
         let ipc = FileIpc::new(PathBuf::from("/tmp/test"));
 
-        let request = AutomateRequest::Invoke {
+        let request = AutomateRequest::Click {
             selector: "@5".to_string(),
+            double_click: false,
         };
 
         let (command, params) = ipc.serialize_request(&request).unwrap();
-        assert_eq!(command, "invoke");
+        assert_eq!(command, "click");
         assert_eq!(params["selector"], "@5");
     }
 

--- a/crates/agent-rdp-daemon/src/automation/scripts/agent.ps1
+++ b/crates/agent-rdp-daemon/src/automation/scripts/agent.ps1
@@ -59,7 +59,7 @@ function Write-Handshake {
         agent_pid = $PID
         started_at = (Get-Date -Format "o")
         capabilities = @(
-            "snapshot", "invoke", "select", "toggle", "expand", "collapse",
+            "snapshot", "click", "select", "toggle", "expand", "collapse",
             "context_menu", "focus", "get", "fill", "clear",
             "scroll", "window", "run", "wait_for", "status"
         )
@@ -153,7 +153,7 @@ function Start-Agent {
                     Write-Log "Executing command: $($request.command)"
                     $response.data = switch ($request.command) {
                         "snapshot"     { Invoke-Snapshot -Params $request.params }
-                        "invoke"       { Invoke-Invoke -Params $request.params }
+                        "click"        { Invoke-Click -Params $request.params }
                         "select"       { Invoke-Select -Params $request.params }
                         "toggle"       { Invoke-Toggle -Params $request.params }
                         "expand"       { Invoke-Expand -Params $request.params }

--- a/crates/agent-rdp-protocol/src/automation.rs
+++ b/crates/agent-rdp-protocol/src/automation.rs
@@ -40,10 +40,13 @@ pub enum AutomateRequest {
         selector: String,
     },
 
-    /// Invoke an element (InvokePattern) - for buttons, links, menu items.
-    Invoke {
+    /// Click an element - for buttons, links, menu items.
+    Click {
         /// Element selector.
         selector: String,
+        /// Use double-click instead of single click.
+        #[serde(default)]
+        double_click: bool,
     },
 
     /// Select an element (SelectionItemPattern) - for list items, radio buttons.
@@ -340,6 +343,21 @@ pub struct RunResult {
     pub pid: Option<u32>,
 }
 
+/// Click action result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClickResult {
+    /// Whether the click was performed.
+    pub clicked: bool,
+    /// Method used (click or double_click).
+    pub method: String,
+    /// X coordinate of click.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub x: Option<i32>,
+    /// Y coordinate of click.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub y: Option<i32>,
+}
+
 /// Handshake data from PowerShell agent.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AutomationHandshake {
@@ -421,13 +439,14 @@ mod tests {
     }
 
     #[test]
-    fn test_invoke_request_serialization() {
-        let req = AutomateRequest::Invoke {
+    fn test_click_request_serialization() {
+        let req = AutomateRequest::Click {
             selector: "@5".to_string(),
+            double_click: false,
         };
 
         let json = serde_json::to_string(&req).unwrap();
-        assert!(json.contains("\"op\":\"invoke\""));
+        assert!(json.contains("\"op\":\"click\""));
         assert!(json.contains("\"selector\":\"@5\""));
     }
 

--- a/crates/agent-rdp-protocol/src/response.rs
+++ b/crates/agent-rdp-protocol/src/response.rs
@@ -1,7 +1,7 @@
 //! Response types for daemon to CLI communication.
 
 use crate::automation::{
-    AccessibilitySnapshot, AutomationStatus, ElementValue, RunResult, WindowInfo,
+    AccessibilitySnapshot, AutomationStatus, ClickResult, ElementValue, RunResult, WindowInfo,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -123,6 +123,9 @@ pub enum ResponseData {
 
     /// Command run result.
     RunResult(RunResult),
+
+    /// Click action result.
+    ClickResult(ClickResult),
 
     /// OCR locate result.
     LocateResult(LocateResult),

--- a/crates/agent-rdp/src/cli.rs
+++ b/crates/agent-rdp/src/cli.rs
@@ -363,10 +363,14 @@ pub enum AutomateAction {
         selector: String,
     },
 
-    /// Invoke an element (InvokePattern) - for buttons, links, menu items
-    Invoke {
+    /// Click an element - for buttons, links, menu items
+    Click {
         /// Element selector
         selector: String,
+
+        /// Use double-click instead of single click
+        #[arg(long, short = 'd')]
+        double_click: bool,
     },
 
     /// Select an element or item (SelectionItemPattern) - for list items, radio buttons

--- a/crates/agent-rdp/src/cli/commands/automate.rs
+++ b/crates/agent-rdp/src/cli/commands/automate.rs
@@ -42,7 +42,7 @@ pub async fn run(
 
         AutomateAction::Focus { selector } => AutomateRequest::Focus { selector },
 
-        AutomateAction::Invoke { selector } => AutomateRequest::Invoke { selector },
+        AutomateAction::Click { selector, double_click } => AutomateRequest::Click { selector, double_click },
 
         AutomateAction::Select { selector, item } => AutomateRequest::Select { selector, item },
 

--- a/crates/agent-rdp/src/output.rs
+++ b/crates/agent-rdp/src/output.rs
@@ -171,6 +171,13 @@ impl Output {
                     }
                 }
             }
+            ResponseData::ClickResult(result) => {
+                if result.method == "double_click" {
+                    println!("Double-clicked at ({}, {})", result.x.unwrap_or(0), result.y.unwrap_or(0));
+                } else {
+                    println!("Clicked at ({}, {})", result.x.unwrap_or(0), result.y.unwrap_or(0));
+                }
+            }
         }
     }
 

--- a/skills/agent-rdp/SKILL.md
+++ b/skills/agent-rdp/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools: Bash(agent-rdp:*)
 ```bash
 agent-rdp connect --host <ip> -u <user> -p <pass> --enable-win-automation
 agent-rdp automate snapshot -i              # See interactive elements
-agent-rdp automate invoke "@e5"             # Invoke button by ref
+agent-rdp automate click "@e5"              # Click button by ref
 agent-rdp automate fill "@e7" "Hello"       # Type into field
 agent-rdp disconnect
 ```
@@ -20,7 +20,7 @@ agent-rdp disconnect
 
 1. Connect with automation: `agent-rdp connect --host <ip> -u <user> -p <pass> --enable-win-automation`
 2. Snapshot: `agent-rdp automate snapshot -i` (get accessibility tree with refs)
-3. Act: `agent-rdp automate invoke @e5` or `agent-rdp automate fill @e7 "text"`
+3. Act: `agent-rdp automate click @e5` or `agent-rdp automate fill @e7 "text"`
 4. Repeat: snapshot → act → snapshot → act...
 
 ## Troubleshooting
@@ -147,8 +147,9 @@ agent-rdp automate snapshot -f             # Start from focused element
 agent-rdp automate snapshot -i -c -d 3     # Combine options
 
 # Pattern-based element operations (use selectors: @eN, #automationId, .className, or name)
-agent-rdp automate invoke "#SaveButton"   # Invoke button (InvokePattern)
-agent-rdp automate invoke "@e5"           # Invoke by ref number
+agent-rdp automate click "#SaveButton"    # Click button
+agent-rdp automate click "@e5"            # Click by ref number
+agent-rdp automate click "@e5" -d         # Double-click (for file list items)
 agent-rdp automate select "@e10"          # Select item (SelectionItemPattern)
 agent-rdp automate select "@e5" --item "Option 1"  # Select item by name in container
 agent-rdp automate toggle "@e7"           # Toggle checkbox (TogglePattern)
@@ -260,14 +261,14 @@ agent-rdp automate fill "@e5" "Hello from automation!"
 # Use File menu to save - expand menu, then invoke menu item
 agent-rdp automate expand "File"          # Expand menu (ExpandCollapsePattern)
 agent-rdp wait 500
-agent-rdp automate invoke "Save As..."    # Invoke menu item
+agent-rdp automate click "Save As..."     # Click menu item
 
 # Wait for Save dialog
 agent-rdp automate wait-for "#FileNameControlHost" --timeout 5000
 
 # Fill filename and save
 agent-rdp automate fill "#FileNameControlHost" "test.txt"
-agent-rdp automate invoke "#1"            # Invoke Save button
+agent-rdp automate click "#1"             # Click Save button
 ```
 
 ## Environment variables

--- a/src/automation.ts
+++ b/src/automation.ts
@@ -10,6 +10,7 @@ import type {
   AutomationWindowInfo,
   AutomationStatus,
   AutomationRunResult,
+  AutomationClickResult,
 } from './types.js';
 
 export interface SnapshotOptions {
@@ -149,14 +150,20 @@ export class AutomationController {
   }
 
   /**
-   * Invoke an element (InvokePattern) - for buttons, links, menu items.
+   * Click an element - for buttons, links, menu items.
+   *
+   * @param selector - Element selector
+   * @param options - Optional settings (e.g., doubleClick for file list items)
+   * @returns Result with click coordinates and method used
    */
-  async invoke(selector: string): Promise<void> {
-    await this.rdp._send({
+  async click(selector: string, options: { doubleClick?: boolean } = {}): Promise<AutomationClickResult> {
+    const response = await this.rdp._send({
       type: 'automate',
-      action: 'invoke',
+      action: 'click',
       selector,
+      double_click: options.doubleClick ?? false,
     });
+    return response.data as unknown as AutomationClickResult;
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -437,6 +437,17 @@ export interface AutomationRunResult {
   pid?: number;
 }
 
+export interface AutomationClickResult {
+  /** Whether the click was performed. */
+  clicked: boolean;
+  /** Method used (click or double_click). */
+  method: string;
+  /** X coordinate of click. */
+  x?: number;
+  /** Y coordinate of click. */
+  y?: number;
+}
+
 // --- Error Class ---
 
 export class RdpError extends Error {


### PR DESCRIPTION
## Summary

- **BREAKING CHANGE**: Renames `invoke` automation command to `click`
- Switches from InvokePattern to mouse click via Win32 APIs to fix modal dialog blocking issue
- Adds double-click support (`-d` flag in CLI, `doubleClick` option in TypeScript)
- Returns click coordinates in result

## Problem

The `invoke` command using InvokePattern.Invoke() would block indefinitely when the invoked action opened a modal dialog (e.g., Save dialog). This is a known Windows UI Automation limitation.

## Solution

Following the approach used by FlaUI and other UI automation frameworks:
- Get element's bounding rectangle
- Calculate center coordinates
- Use Win32 `SetCursorPos` and `mouse_event` APIs for actual mouse input
- This is non-blocking and works even when dialogs open

## Changes

- `AutomateRequest::Invoke` → `AutomateRequest::Click`
- `InvokeResult` → `ClickResult` (with `clicked`, `method`, `x`, `y` fields)
- CLI: `automate invoke` → `automate click` with `-d` for double-click
- TypeScript: `automation.invoke()` → `automation.click({ doubleClick?: boolean })`
- PowerShell: `Invoke-Invoke` → `Invoke-Click` using Win32 mouse APIs
- Updated README.md and SKILL.md documentation

## Test plan

- [ ] Test single click on button elements
- [ ] Test double-click on file list items
- [ ] Test clicking element that opens modal dialog (should not block)
- [ ] Verify click coordinates are returned correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)