### PR TITLE
docs: update CLAUDE.md for monorepo structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ pnpm install          # Install dependencies
 pnpm build            # Build native binary + copy to bin/
 pnpm build:ts         # Build TypeScript only
 pnpm build:all        # Cross-compile all platforms (needs `cross`)
+pnpm cli              # Run the CLI (uses local platform binary)
 pnpm example          # Run example script
 ```
 
@@ -30,12 +31,22 @@ agent-rdp is a CLI tool for AI agents to control Windows Remote Desktop sessions
 - **agent-rdp-daemon** - Background process maintaining RDP connection and processing commands
 - **agent-rdp-protocol** - Shared request/response types for IPC communication
 
+### Monorepo Structure
+
+This is a pnpm workspace monorepo:
+
+- **packages/agent-rdp/** - Main npm package with TypeScript SDK and CLI entry point
+- **packages/{platform}-{arch}/** - Platform-specific packages containing native binaries (e.g., `darwin-arm64`, `linux-x64`, `win32-x64`)
+
+The main package uses `optionalDependencies` with `os`/`cpu` fields so npm only installs the binary for the user's platform.
+
 ### TypeScript Structure
 
-- **src/index.ts** - Main `RdpSession` class with sub-controllers (mouse, keyboard, scroll, clipboard, drives)
-- **src/client.ts** - IPC client for Unix socket / TCP communication with daemon
-- **src/daemon.ts** - Daemon lifecycle management (spawn, health check)
-- **src/types.ts** - TypeScript interfaces mirroring `agent-rdp-protocol`
+- **packages/agent-rdp/src/index.ts** - Main `RdpSession` class with sub-controllers (mouse, keyboard, scroll, clipboard, drives)
+- **packages/agent-rdp/src/client.ts** - IPC client for Unix socket / TCP communication with daemon
+- **packages/agent-rdp/src/daemon.ts** - Daemon lifecycle management (spawn, health check, binary resolution)
+- **packages/agent-rdp/src/types.ts** - TypeScript interfaces mirroring `agent-rdp-protocol`
+- **packages/agent-rdp/bin/cli.js** - CLI entry point that resolves and executes the platform binary
 
 ### Daemon-per-Session Model
 
@@ -118,10 +129,13 @@ ci: CI changes               # No version bump, hidden from changelog
 
 1. Push commits with conventional commit messages to `main`
 2. Release-please creates/updates a "Release PR" with:
-   - Version bump in `package.json` and `Cargo.toml` files
+   - Version bump in `package.json` files
    - Updated `CHANGELOG.md`
 3. Merge the Release PR when ready to publish
 4. Tag creation triggers the release workflow:
    - Builds binaries for all platforms
    - Creates GitHub release with binaries
-   - Publishes to npm with provenance (uses OIDC trusted publishers, no npm token needed)
+   - Publishes platform packages (`@agent-rdp/{platform}-{arch}`) to npm
+   - Publishes main package (`agent-rdp`) to npm with provenance
+
+**Manual Release**: If release-please fails to create a release, you can manually trigger the workflow via `workflow_dispatch` with a tag name, or push a tag matching `agent-rdp-v*`.


### PR DESCRIPTION
## Summary
- Add `pnpm cli` command to build commands
- Document monorepo structure with platform-specific packages
- Update TypeScript paths to `packages/agent-rdp/src/`
- Add manual release trigger documentation

## Test plan
- [x] Review documentation changes for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)