### PR TITLE
fix: configure release-please to manage all platform packages

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,9 @@
 {
-  "packages/agent-rdp": "0.5.0"
+  "packages/agent-rdp": "0.5.0",
+  "packages/darwin-arm64": "0.5.0",
+  "packages/darwin-x64": "0.5.0",
+  "packages/linux-x64": "0.5.0",
+  "packages/linux-arm64": "0.5.0",
+  "packages/win32-x64": "0.5.0",
+  "packages/win32-arm64": "0.5.0"
 }

--- a/packages/darwin-arm64/package.json
+++ b/packages/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-rdp/darwin-arm64",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "agent-rdp native binary for macOS ARM64 (Apple Silicon)",
   "repository": {
     "type": "git",

--- a/packages/darwin-x64/package.json
+++ b/packages/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-rdp/darwin-x64",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "agent-rdp native binary for macOS x64 (Intel)",
   "repository": {
     "type": "git",

--- a/packages/linux-arm64/package.json
+++ b/packages/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-rdp/linux-arm64",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "agent-rdp native binary for Linux ARM64",
   "repository": {
     "type": "git",

--- a/packages/linux-x64/package.json
+++ b/packages/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-rdp/linux-x64",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "agent-rdp native binary for Linux x64",
   "repository": {
     "type": "git",

--- a/packages/win32-arm64/package.json
+++ b/packages/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-rdp/win32-arm64",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "agent-rdp native binary for Windows ARM64",
   "repository": {
     "type": "git",

--- a/packages/win32-x64/package.json
+++ b/packages/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-rdp/win32-x64",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "agent-rdp native binary for Windows x64",
   "repository": {
     "type": "git",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -18,8 +18,37 @@
         {"type": "chore", "section": "Maintenance", "hidden": true},
         {"type": "test", "section": "Tests", "hidden": true},
         {"type": "ci", "section": "CI", "hidden": true}
-      ],
-"extra-files": []
+      ]
+    },
+    "packages/darwin-arm64": {
+      "release-type": "node",
+      "component": "darwin-arm64",
+      "skip-github-release": true
+    },
+    "packages/darwin-x64": {
+      "release-type": "node",
+      "component": "darwin-x64",
+      "skip-github-release": true
+    },
+    "packages/linux-x64": {
+      "release-type": "node",
+      "component": "linux-x64",
+      "skip-github-release": true
+    },
+    "packages/linux-arm64": {
+      "release-type": "node",
+      "component": "linux-arm64",
+      "skip-github-release": true
+    },
+    "packages/win32-x64": {
+      "release-type": "node",
+      "component": "win32-x64",
+      "skip-github-release": true
+    },
+    "packages/win32-arm64": {
+      "release-type": "node",
+      "component": "win32-arm64",
+      "skip-github-release": true
     }
   },
   "plugins": [
@@ -27,7 +56,13 @@
       "type": "linked-versions",
       "groupName": "agent-rdp packages",
       "components": [
-        "agent-rdp"
+        "agent-rdp",
+        "darwin-arm64",
+        "darwin-x64",
+        "linux-x64",
+        "linux-arm64",
+        "win32-x64",
+        "win32-arm64"
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- Add all 6 platform packages to release-please config as separate components
- Use `linked-versions` plugin to keep all packages in sync
- Set `skip-github-release: true` for platform packages (only main package gets GitHub release)
- Update platform package versions to 0.5.0 to match main package

This fixes the issue where platform packages weren't being versioned by release-please because we couldn't use `../` relative paths in `extra-files`.

## Test plan
- [ ] Merge this PR
- [ ] Push a `fix:` commit to trigger release-please
- [ ] Verify release-please PR updates all package versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)