### PR TITLE
fix: add postinstall script to set binary executable permission

### DIFF
--- a/packages/darwin-arm64/package.json
+++ b/packages/darwin-arm64/package.json
@@ -11,5 +11,8 @@
   "os": ["darwin"],
   "cpu": ["arm64"],
   "files": ["bin", "models"],
+  "scripts": {
+    "postinstall": "chmod +x bin/agent-rdp 2>/dev/null || true"
+  },
   "preferUnplugged": true
 }

--- a/packages/darwin-x64/package.json
+++ b/packages/darwin-x64/package.json
@@ -11,5 +11,8 @@
   "os": ["darwin"],
   "cpu": ["x64"],
   "files": ["bin", "models"],
+  "scripts": {
+    "postinstall": "chmod +x bin/agent-rdp 2>/dev/null || true"
+  },
   "preferUnplugged": true
 }

--- a/packages/linux-arm64/package.json
+++ b/packages/linux-arm64/package.json
@@ -11,5 +11,8 @@
   "os": ["linux"],
   "cpu": ["arm64"],
   "files": ["bin", "models"],
+  "scripts": {
+    "postinstall": "chmod +x bin/agent-rdp 2>/dev/null || true"
+  },
   "preferUnplugged": true
 }

--- a/packages/linux-x64/package.json
+++ b/packages/linux-x64/package.json
@@ -11,5 +11,8 @@
   "os": ["linux"],
   "cpu": ["x64"],
   "files": ["bin", "models"],
+  "scripts": {
+    "postinstall": "chmod +x bin/agent-rdp 2>/dev/null || true"
+  },
   "preferUnplugged": true
 }


### PR DESCRIPTION
## Summary

- Adds postinstall script to Unix platform packages (darwin-arm64, darwin-x64, linux-arm64, linux-x64)
- The script runs `chmod +x bin/agent-rdp` after installation
- This fixes the issue where npm strips execute permissions during publish

## Problem

After `npm install agent-rdp`, the binary had no execute permission:
```
$ agent-rdp --help
(no output)
```

## Solution

Each Unix platform package now includes:
```json
"scripts": {
  "postinstall": "chmod +x bin/agent-rdp 2>/dev/null || true"
}
```

The `2>/dev/null || true` ensures the script doesn't fail if run on Windows or if the binary doesn't exist.

## Test plan

- [ ] Install agent-rdp on macOS/Linux
- [ ] Verify `agent-rdp --help` produces output

🤖 Generated with [Claude Code](https://claude.com/claude-code)