### PR TITLE
fix: configure release-please to update Cargo.toml

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
+  ".": "0.5.1",
   "packages/agent-rdp": "0.5.1",
   "packages/darwin-arm64": "0.5.1",
   "packages/darwin-x64": "0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0" # x-release-please-version
+version = "0.5.1" # x-release-please-version
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/anthropics/agent-rdp"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,13 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "group-pull-request-title-pattern": "chore(main): release ${version}",
+  "group-pull-request-title-pattern": "chore(main): release v${version}",
   "packages": {
+    ".": {
+      "release-type": "rust",
+      "component": "agent-rdp-rust",
+      "skip-github-release": true,
+      "changelog-path": "CHANGELOG-rust.md"
+    },
     "packages/agent-rdp": {
       "release-type": "node",
       "component": "agent-rdp",
@@ -56,6 +62,7 @@
       "type": "linked-versions",
       "groupName": "agent-rdp packages",
       "components": [
+        "agent-rdp-rust",
         "agent-rdp",
         "darwin-arm64",
         "darwin-x64",


### PR DESCRIPTION
## Summary

- Adds root package with `release-type: "rust"` to update workspace Cargo.toml version
- Includes the rust component in the linked-versions plugin so all versions stay in sync
- Fixes PR title pattern to include "v" prefix: `chore(main): release v${version}`
- Syncs Cargo.toml version to 0.5.1 to match npm packages

## Changes

- **release-please-config.json**: Added "." package for Rust workspace
- **.release-please-manifest.json**: Added "." entry with version 0.5.1
- **Cargo.toml**: Updated version from 0.4.0 to 0.5.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)