### PR TITLE
fix: use simple release type with generic updater for Cargo.toml

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,10 +3,16 @@
   "group-pull-request-title-pattern": "chore(main): release v${version}",
   "packages": {
     ".": {
-      "release-type": "rust",
+      "release-type": "simple",
       "component": "agent-rdp-rust",
       "skip-github-release": true,
-      "changelog-path": "CHANGELOG-rust.md"
+      "changelog-path": "CHANGELOG-rust.md",
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "Cargo.toml"
+        }
+      ]
     },
     "packages/agent-rdp": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

The "rust" release type expects a `[package]` section in Cargo.toml, but we use `[workspace.package]`. This switches to the "simple" release type with a generic updater that uses the `x-release-please-version` annotation already in our Cargo.toml.

## Changes

Changed the root package config from:
```json
"release-type": "rust"
```

To:
```json
"release-type": "simple",
"extra-files": [
  {
    "type": "generic",
    "path": "Cargo.toml"
  }
]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)