### PR TITLE
fix: add bump-patch-for-minor-pre-major to all packages

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      tag_name: ${{ steps.release.outputs['packages/agent-rdp--tag_name'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -33,7 +33,7 @@ jobs:
 
   build:
     needs: release-please
-    if: ${{ always() && (needs.release-please.outputs.release_created || github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')) }}
+    if: ${{ always() && (needs.release-please.outputs.releases_created || github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')) }}
     strategy:
       matrix:
         include:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -37,31 +37,43 @@
     "packages/darwin-arm64": {
       "release-type": "node",
       "component": "darwin-arm64",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
       "skip-github-release": true
     },
     "packages/darwin-x64": {
       "release-type": "node",
       "component": "darwin-x64",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
       "skip-github-release": true
     },
     "packages/linux-x64": {
       "release-type": "node",
       "component": "linux-x64",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
       "skip-github-release": true
     },
     "packages/linux-arm64": {
       "release-type": "node",
       "component": "linux-arm64",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
       "skip-github-release": true
     },
     "packages/win32-x64": {
       "release-type": "node",
       "component": "win32-x64",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
       "skip-github-release": true
     },
     "packages/win32-arm64": {
       "release-type": "node",
       "component": "win32-arm64",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
       "skip-github-release": true
     }
   },


### PR DESCRIPTION
## Summary
- Adds `bump-minor-pre-major: true` and `bump-patch-for-minor-pre-major: true` to all platform packages in release-please config
- This ensures that feat commits bump patch (not minor) and breaking changes bump minor (not major) while we're still pre-1.0
- Previously only the root package and `packages/agent-rdp` had these settings, causing linked-versions to calculate a major bump

## Test plan
- [ ] Merge and verify next release-please PR shows correct version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)