### PR TITLE
feat: improve CLI snapshot output with disabled tags and increased depth

### DIFF
--- a/crates/agent-rdp-daemon/src/automation/scripts/lib/snapshot.ps1
+++ b/crates/agent-rdp-daemon/src/automation/scripts/lib/snapshot.ps1
@@ -80,7 +80,7 @@ function Test-IsEmptyStructural {
 function Get-AccessibilityTree {
     param(
         [System.Windows.Automation.AutomationElement]$Element,
-        [int]$MaxDepth = 5,
+        [int]$MaxDepth = 10,
         [int]$CurrentDepth = 0,
         [ref]$RefCounter,
         [bool]$InteractiveOnly = $false,
@@ -193,7 +193,7 @@ function Invoke-Snapshot {
     $refCounter = [ref]0
     $script:SnapshotId = [guid]::NewGuid().ToString().Substring(0, 8)
 
-    $maxDepth = if ($null -ne $Params.max_depth) { [int]$Params.max_depth } else { 5 }
+    $maxDepth = if ($null -ne $Params.max_depth) { [int]$Params.max_depth } else { 10 }
     $interactiveOnly = if ($null -ne $Params.interactive_only) { $Params.interactive_only } else { $false }
     $compact = if ($null -ne $Params.compact) { $Params.compact } else { $false }
     $focused = if ($null -ne $Params.focused) { $Params.focused } else { $false }

--- a/crates/agent-rdp-daemon/src/handlers/automate.rs
+++ b/crates/agent-rdp-daemon/src/handlers/automate.rs
@@ -177,7 +177,7 @@ fn parse_snapshot_response(data: serde_json::Value) -> anyhow::Result<Accessibil
         .to_string();
     let ref_count = data["ref_count"].as_u64().unwrap_or(0) as u32;
     let truncated = data["truncated"].as_bool().unwrap_or(false);
-    let max_depth = data["max_depth"].as_u64().unwrap_or(5) as u32;
+    let max_depth = data["max_depth"].as_u64().unwrap_or(10) as u32;
     let root_data = &data["root"];
 
     let root = parse_element(root_data)?;

--- a/crates/agent-rdp/src/cli.rs
+++ b/crates/agent-rdp/src/cli.rs
@@ -334,8 +334,8 @@ pub enum AutomateAction {
         #[arg(short = 'c', long)]
         compact: bool,
 
-        /// Maximum tree depth (default: 5)
-        #[arg(short = 'd', long, default_value = "5")]
+        /// Maximum tree depth (default: 10)
+        #[arg(short = 'd', long, default_value = "10")]
         depth: u32,
 
         /// Scope to a specific element (window, panel, etc.) via selector

--- a/crates/agent-rdp/src/output.rs
+++ b/crates/agent-rdp/src/output.rs
@@ -222,8 +222,25 @@ impl Output {
             }
         }
 
-        // Add disabled tag if element is not enabled
-        if !element.states.contains(&"enabled".to_string()) {
+        // Add disabled tag if element is interactive but not enabled
+        // Interactive = focusable OR has interactive patterns
+        let interactive_patterns = [
+            "invoke",
+            "value",
+            "toggle",
+            "selectionitem",
+            "expandcollapse",
+            "rangevalue",
+            "scroll",
+        ];
+        let is_focusable = element.states.contains(&"focusable".to_string());
+        let has_interactive_pattern = element
+            .patterns
+            .iter()
+            .any(|p| interactive_patterns.contains(&p.as_str()));
+        let is_interactive = is_focusable || has_interactive_pattern;
+
+        if is_interactive && !element.states.contains(&"enabled".to_string()) {
             attrs.push("disabled".to_string());
         }
 

--- a/crates/agent-rdp/src/output.rs
+++ b/crates/agent-rdp/src/output.rs
@@ -222,6 +222,11 @@ impl Output {
             }
         }
 
+        // Add disabled tag if element is not enabled
+        if !element.states.contains(&"enabled".to_string()) {
+            attrs.push("disabled".to_string());
+        }
+
         if !attrs.is_empty() {
             line.push_str(&format!(" [{}]", attrs.join(", ")));
         }


### PR DESCRIPTION
## Summary
- Show `disabled` tag in CLI snapshot tree output for interactive elements that are not enabled
- Only display the tag for interactive elements (those with focusable state or interactive patterns)
- Increase default snapshot depth from 5 to 10 for better coverage

## Example output
```
- Window "My App" [ref=e1]
  - Button "Submit" [ref=e2]
  - Button "Cancel" [ref=e3, disabled]
  - TextBox "Name" [ref=e4, disabled]
```

## Test plan
- [x] Run `agent-rdp automate snapshot` and verify disabled elements show the tag
- [x] Verify non-interactive elements (Text, Pane) don't show disabled tag
- [x] Verify default depth is now 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)