### PR TITLE
feat: add AGENT_RDP_HOST and AGENT_RDP_PORT env vars, clean up env var docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,12 +99,12 @@ Input sent as `FastPathInputEvent` (mouse via `MousePdu`, keyboard via scancode 
 
 | Variable | Description |
 |----------|-------------|
-| `AGENT_RDP_SESSION` | Session name (default: "default") |
+| `AGENT_RDP_HOST` | RDP server hostname or IP |
+| `AGENT_RDP_PORT` | RDP server port (default: 3389) |
 | `AGENT_RDP_USERNAME` | RDP username |
 | `AGENT_RDP_PASSWORD` | RDP password |
+| `AGENT_RDP_SESSION` | Session name (default: "default") |
 | `AGENT_RDP_STREAM_PORT` | WebSocket streaming port (0 = disabled) |
-| `AGENT_RDP_STREAM_FPS` | Frame rate for streaming (default: 10) |
-| `AGENT_RDP_STREAM_QUALITY` | JPEG quality 0-100 (default: 80) |
 
 ## Release Process
 

--- a/README.md
+++ b/README.md
@@ -310,12 +310,12 @@ agent-rdp --json screenshot --base64
 
 | Variable | Description |
 |----------|-------------|
-| `AGENT_RDP_SESSION` | Session name (default: "default") |
+| `AGENT_RDP_HOST` | RDP server hostname or IP |
+| `AGENT_RDP_PORT` | RDP server port (default: 3389) |
 | `AGENT_RDP_USERNAME` | RDP username |
 | `AGENT_RDP_PASSWORD` | RDP password |
+| `AGENT_RDP_SESSION` | Session name (default: "default") |
 | `AGENT_RDP_STREAM_PORT` | WebSocket streaming port (0 = disabled) |
-| `AGENT_RDP_STREAM_FPS` | Frame rate for streaming (default: 10) |
-| `AGENT_RDP_STREAM_QUALITY` | JPEG quality 0-100 (default: 80) |
 
 ## Node.js API
 

--- a/crates/agent-rdp/src/cli.rs
+++ b/crates/agent-rdp/src/cli.rs
@@ -89,8 +89,8 @@ pub struct ConnectArgs {
     #[arg(long, env = "AGENT_RDP_HOST", required = true)]
     pub host: String,
 
-    /// Server port
-    #[arg(long, default_value = "3389")]
+    /// Server port (or set AGENT_RDP_PORT)
+    #[arg(long, default_value = "3389", env = "AGENT_RDP_PORT")]
     pub port: u16,
 
     /// Username (or set AGENT_RDP_USERNAME)

--- a/docs/WEBSOCKET.md
+++ b/docs/WEBSOCKET.md
@@ -19,14 +19,6 @@ Start a session with the `--stream-port` flag:
 agent-rdp --stream-port 9224 connect --host 192.168.1.100 -u Admin -p secret
 ```
 
-Or use environment variables:
-
-```bash
-export AGENT_RDP_STREAM_PORT=9224
-export AGENT_RDP_STREAM_FPS=10
-export AGENT_RDP_STREAM_QUALITY=80
-```
-
 ### Accessing the Viewer
 
 The daemon serves both the WebSocket API and an embedded HTML viewer on the same port:
@@ -41,14 +33,6 @@ You can also use the CLI to open the viewer in your browser:
 ```bash
 agent-rdp view --port 9224
 ```
-
-## Environment Variables
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `AGENT_RDP_STREAM_PORT` | 0 (disabled) | WebSocket server port |
-| `AGENT_RDP_STREAM_FPS` | 10 | Frame broadcast rate (frames per second) |
-| `AGENT_RDP_STREAM_QUALITY` | 80 | JPEG compression quality (0-100) |
 
 ## Message Types
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -66,9 +66,4 @@ Browser-based viewer for debugging and interactive control.
 - Keyboard input (typing, special keys)
 - Fullscreen mode
 
-**Configuration via environment:**
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `AGENT_RDP_STREAM_PORT` | 0 (disabled) | WebSocket server port |
-| `AGENT_RDP_STREAM_FPS` | 10 | Frame rate |
-| `AGENT_RDP_STREAM_QUALITY` | 80 | JPEG quality (0-100) |
+**Enable streaming:** Use `--stream-port` flag when connecting (e.g., `agent-rdp --stream-port 9224 connect ...`).

--- a/skills/agent-rdp/SKILL.md
+++ b/skills/agent-rdp/SKILL.md
@@ -274,10 +274,12 @@ agent-rdp automate click "#1"             # Click Save button
 ## Environment variables
 
 ```bash
+export AGENT_RDP_HOST=192.168.1.100
+export AGENT_RDP_PORT=3389
 export AGENT_RDP_USERNAME=Administrator
 export AGENT_RDP_PASSWORD=secret
 export AGENT_RDP_SESSION=default
-agent-rdp connect --host 192.168.1.100    # Uses env vars for credentials
+agent-rdp connect    # Uses env vars for connection
 ```
 
 ## Debugging with WebSocket streaming


### PR DESCRIPTION
- Add AGENT_RDP_PORT env var support to CLI for RDP connection port
- Add AGENT_RDP_HOST to documentation (was already implemented)
- Remove undocumented AGENT_RDP_STREAM_FPS and AGENT_RDP_STREAM_QUALITY
  from docs (they only work in daemon, not from CLI)
- Update SKILL.md, CLAUDE.md, README.md, examples/README.md, WEBSOCKET.md