### PR TITLE
fix: add README files to platform packages and fix relative refs in main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ On the remote Windows machine, mapped drives appear in File Explorer as network 
 
 Interact with Windows applications programmatically via the Windows UI Automation API using native patterns (InvokePattern, SelectionItemPattern, TogglePattern, etc.). When enabled, a PowerShell agent is injected into the remote session that captures the accessibility tree and performs actions. Communication between the CLI and the agent uses a Dynamic Virtual Channel (DVC) for fast bidirectional IPC.
 
-For detailed documentation, see [docs/AUTOMATION.md](docs/AUTOMATION.md).
+For detailed documentation, see [AUTOMATION.md](https://github.com/thisnick/agent-rdp/blob/main/docs/AUTOMATION.md).
 
 ```bash
 # Connect with automation enabled
@@ -412,7 +412,7 @@ await rdp.connect({...});
 const streamUrl = rdp.getStreamUrl(); // "ws://localhost:9224"
 ```
 
-For the complete WebSocket protocol specification (message types, clipboard flow, input handling), see [docs/WEBSOCKET.md](docs/WEBSOCKET.md).
+For the complete WebSocket protocol specification (message types, clipboard flow, input handling), see [WEBSOCKET.md](https://github.com/thisnick/agent-rdp/blob/main/docs/WEBSOCKET.md).
 
 ## Architecture
 

--- a/packages/darwin-arm64/README.md
+++ b/packages/darwin-arm64/README.md
@@ -1,0 +1,17 @@
+# @agent-rdp/darwin-arm64
+
+Native binary package for macOS ARM64 (Apple Silicon).
+
+This is a platform-specific package that contains the native binary for agent-rdp. You should not install this package directly - instead, install the main package:
+
+```bash
+npm install agent-rdp
+```
+
+The main package will automatically install the correct platform-specific binary for your system.
+
+For documentation, see the [agent-rdp README](https://github.com/thisnick/agent-rdp#readme).
+
+## License
+
+MIT OR Apache-2.0

--- a/packages/darwin-arm64/package.json
+++ b/packages/darwin-arm64/package.json
@@ -16,7 +16,8 @@
   ],
   "files": [
     "bin",
-    "models"
+    "models",
+    "README.md"
   ],
   "scripts": {
     "postinstall": "chmod +x bin/agent-rdp 2>/dev/null || true"

--- a/packages/darwin-x64/README.md
+++ b/packages/darwin-x64/README.md
@@ -1,0 +1,17 @@
+# @agent-rdp/darwin-x64
+
+Native binary package for macOS x64 (Intel).
+
+This is a platform-specific package that contains the native binary for agent-rdp. You should not install this package directly - instead, install the main package:
+
+```bash
+npm install agent-rdp
+```
+
+The main package will automatically install the correct platform-specific binary for your system.
+
+For documentation, see the [agent-rdp README](https://github.com/thisnick/agent-rdp#readme).
+
+## License
+
+MIT OR Apache-2.0

--- a/packages/darwin-x64/package.json
+++ b/packages/darwin-x64/package.json
@@ -16,7 +16,8 @@
   ],
   "files": [
     "bin",
-    "models"
+    "models",
+    "README.md"
   ],
   "scripts": {
     "postinstall": "chmod +x bin/agent-rdp 2>/dev/null || true"

--- a/packages/linux-arm64/README.md
+++ b/packages/linux-arm64/README.md
@@ -1,0 +1,17 @@
+# @agent-rdp/linux-arm64
+
+Native binary package for Linux ARM64.
+
+This is a platform-specific package that contains the native binary for agent-rdp. You should not install this package directly - instead, install the main package:
+
+```bash
+npm install agent-rdp
+```
+
+The main package will automatically install the correct platform-specific binary for your system.
+
+For documentation, see the [agent-rdp README](https://github.com/thisnick/agent-rdp#readme).
+
+## License
+
+MIT OR Apache-2.0

--- a/packages/linux-arm64/package.json
+++ b/packages/linux-arm64/package.json
@@ -16,7 +16,8 @@
   ],
   "files": [
     "bin",
-    "models"
+    "models",
+    "README.md"
   ],
   "scripts": {
     "postinstall": "chmod +x bin/agent-rdp 2>/dev/null || true"

--- a/packages/linux-x64/README.md
+++ b/packages/linux-x64/README.md
@@ -1,0 +1,17 @@
+# @agent-rdp/linux-x64
+
+Native binary package for Linux x64.
+
+This is a platform-specific package that contains the native binary for agent-rdp. You should not install this package directly - instead, install the main package:
+
+```bash
+npm install agent-rdp
+```
+
+The main package will automatically install the correct platform-specific binary for your system.
+
+For documentation, see the [agent-rdp README](https://github.com/thisnick/agent-rdp#readme).
+
+## License
+
+MIT OR Apache-2.0

--- a/packages/linux-x64/package.json
+++ b/packages/linux-x64/package.json
@@ -16,7 +16,8 @@
   ],
   "files": [
     "bin",
-    "models"
+    "models",
+    "README.md"
   ],
   "scripts": {
     "postinstall": "chmod +x bin/agent-rdp 2>/dev/null || true"

--- a/packages/win32-arm64/README.md
+++ b/packages/win32-arm64/README.md
@@ -1,0 +1,17 @@
+# @agent-rdp/win32-arm64
+
+Native binary package for Windows ARM64.
+
+This is a platform-specific package that contains the native binary for agent-rdp. You should not install this package directly - instead, install the main package:
+
+```bash
+npm install agent-rdp
+```
+
+The main package will automatically install the correct platform-specific binary for your system.
+
+For documentation, see the [agent-rdp README](https://github.com/thisnick/agent-rdp#readme).
+
+## License
+
+MIT OR Apache-2.0

--- a/packages/win32-arm64/package.json
+++ b/packages/win32-arm64/package.json
@@ -16,7 +16,8 @@
   ],
   "files": [
     "bin",
-    "models"
+    "models",
+    "README.md"
   ],
   "preferUnplugged": true
 }

--- a/packages/win32-x64/README.md
+++ b/packages/win32-x64/README.md
@@ -1,0 +1,17 @@
+# @agent-rdp/win32-x64
+
+Native binary package for Windows x64.
+
+This is a platform-specific package that contains the native binary for agent-rdp. You should not install this package directly - instead, install the main package:
+
+```bash
+npm install agent-rdp
+```
+
+The main package will automatically install the correct platform-specific binary for your system.
+
+For documentation, see the [agent-rdp README](https://github.com/thisnick/agent-rdp#readme).
+
+## License
+
+MIT OR Apache-2.0

--- a/packages/win32-x64/package.json
+++ b/packages/win32-x64/package.json
@@ -16,7 +16,8 @@
   ],
   "files": [
     "bin",
-    "models"
+    "models",
+    "README.md"
   ],
   "preferUnplugged": true
 }


### PR DESCRIPTION
## Summary
This PR adds README files to all platform-specific binary packages and updates documentation links in the main README to use absolute GitHub URLs instead of relative paths.

## Key Changes
- **Added README.md files** to all 6 platform-specific packages:
  - `@agent-rdp/darwin-arm64`
  - `@agent-rdp/darwin-x64`
  - `@agent-rdp/linux-arm64`
  - `@agent-rdp/linux-x64`
  - `@agent-rdp/win32-arm64`
  - `@agent-rdp/win32-x64`

- **Updated package.json files** for all platform packages to include `README.md` in the `files` array for distribution

- **Fixed documentation links** in main README.md:
  - Changed relative link `docs/AUTOMATION.md` to absolute GitHub URL
  - Changed relative link `docs/WEBSOCKET.md` to absolute GitHub URL

## Implementation Details
Each platform-specific package README includes:
- Clear identification of the platform (e.g., "macOS ARM64 (Apple Silicon)")
- Instructions that users should install the main `agent-rdp` package instead
- Reference to the main project README on GitHub
- MIT OR Apache-2.0 license notice

This improves the user experience when viewing these packages on npm.org, as they will now see helpful information instead of a missing README, and the main README links will work correctly regardless of where the documentation is viewed from.

https://claude.ai/code/session_01X9GrLX4PVdbbpcQ8pATH4Q