### PR TITLE
Use cross for Linux builds to ensure glibc 2.31 compatibility

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -68,7 +68,20 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # Use cross for Linux builds to target older glibc (2.31) for broad compatibility.
+      # Without this, ubuntu-latest (24.04) produces binaries requiring glibc 2.39+.
+      - name: Install cross
+        if: contains(matrix.target, 'linux')
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
+      - name: Build (Linux)
+        if: contains(matrix.target, 'linux')
+        run: cross build --release --target ${{ matrix.target }}
+
       - name: Build
+        if: ${{ !contains(matrix.target, 'linux') }}
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
         run: cargo build --release --target ${{ matrix.target }}


### PR DESCRIPTION
## Summary
Updated the release build workflow to use the `cross` tool for Linux targets, ensuring binaries are compatible with glibc 2.31 and older systems. This prevents the ubuntu-latest (24.04) environment from producing binaries that require glibc 2.39+.

## Changes
- Added a new step to install the `cross` tool for Linux builds
- Created a separate build step for Linux targets using `cross build` instead of `cargo build`
- Updated the existing build step to skip Linux targets (only runs for non-Linux platforms)
- Added explanatory comments documenting the rationale for using `cross`

## Implementation Details
The workflow now conditionally uses `cross` for any target containing "linux" in its name, while maintaining the existing `cargo build` approach for other platforms (macOS, Windows, etc.). This ensures broad compatibility across different glibc versions without affecting the build process for non-Linux targets.

https://claude.ai/code/session_01PgK6kkizuvPvv6oq1Ku2QW