### PR TITLE
fix: use clipboard paste and longer delay for automation bootstrap

### DIFF
--- a/crates/agent-rdp-daemon/src/automation/bootstrap.rs
+++ b/crates/agent-rdp-daemon/src/automation/bootstrap.rs
@@ -106,13 +106,23 @@ impl AutomationBootstrap {
 
         debug!("PowerShell command: {}", ps_command);
 
+        // Set the command in clipboard first (paste is more reliable than typing
+        // long commands character-by-character into the Run dialog)
+        rdp.clipboard_set(ps_command).await
+            .map_err(|e| anyhow::anyhow!("Failed to set clipboard: {}", e))?;
+        sleep(Duration::from_millis(300)).await;
+
         // Press Win+R to open Run dialog
         rdp.send_key_press("super+r").await?;
-        sleep(Duration::from_millis(500)).await;
 
-        // Type the PowerShell command
-        rdp.send_text(&ps_command).await?;
-        sleep(Duration::from_millis(200)).await;
+        // Wait long enough for the Run dialog to appear and grab focus.
+        // 500ms is insufficient when foreground apps (Steam, browsers, etc.)
+        // are active — the dialog can take 1-2s to steal focus.
+        sleep(Duration::from_millis(2000)).await;
+
+        // Paste the command from clipboard (avoids character-by-character timing issues)
+        rdp.send_key_press("ctrl+v").await?;
+        sleep(Duration::from_millis(500)).await;
 
         // Press Enter to execute
         rdp.send_key_press("return").await?;


### PR DESCRIPTION
## Summary

- Fixes automation agent bootstrap failure when a foreground app (e.g. Steam, browser) is active during `--enable-win-automation` connection
- The 500ms delay after Win+R was insufficient for the Run dialog to appear and grab focus, causing the typed PowerShell launch command to be partially or fully lost to the foreground app
- Replaced character-by-character `send_text()` with clipboard pre-load + Ctrl+V paste, and increased Win+R delay from 500ms to 2000ms

## Problem

When connecting with `--enable-win-automation`, the bootstrap sequence:
1. Presses Win+R
2. Waits 500ms
3. Types the full PowerShell command character-by-character

If another application (Steam, browser, etc.) is maximized and has keyboard focus, the Run dialog takes 1-2+ seconds to appear. Characters typed during this window go to the foreground app and are lost. The result is a truncated or garbled command in the Run dialog, the PowerShell agent never starts, and the DVC handshake times out with:

```
Automation agent not ready. Agent may still be starting or failed to launch via DVC
```

## Fix

1. **Pre-load clipboard**: Set the launch command in clipboard *before* pressing Win+R
2. **Increase delay**: Wait 2000ms after Win+R (vs 500ms) for the dialog to appear
3. **Paste via Ctrl+V**: Single atomic paste operation instead of ~150 individual keystroke events

## Test plan

- [x] Connected with `--enable-win-automation` while Steam was maximized in foreground
- [x] `automate status` returns agent_running=true on first attempt
- [x] `automate run "hostname" --wait` returns correct output
- [x] `automate snapshot -i -c -d 2` returns accessibility tree
- [x] Disconnect + reconnect cycle works consistently
- [x] All existing tests pass (`cargo test -p agent-rdp-daemon` — 19 tests)
- [x] Desktop remains clean (no leftover dialogs or visible PowerShell windows)